### PR TITLE
Add custom message for FormulaParseError

### DIFF
--- a/freeride/exceptions.py
+++ b/freeride/exceptions.py
@@ -1,7 +1,25 @@
 class FreeRideError(Exception):
     """Base class for all FreeRide exceptions."""
 
+    def __init__(self, message: str | None = None) -> None:
+        if message is None:
+            message = "An unspecified FreeRide error occurred."
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self) -> str:  # pragma: no cover - simple return
+        return self.message
+
+    def __repr__(self) -> str:  # pragma: no cover - simple return
+        return f"{self.__class__.__name__}('{self.message}')"
+
 
 class FormulaParseError(FreeRideError):
     """Error raised when parsing a formula string fails."""
+
+    def __init__(self, message: str | None = None) -> None:
+        if message is None:
+            message = "Unable to parse formula string."
+        super().__init__(message)
+
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,21 @@
+import pytest
+from freeride.exceptions import FreeRideError, FormulaParseError
+
+
+def test_base_error_defaults():
+    err = FreeRideError()
+    assert str(err) == "An unspecified FreeRide error occurred."
+    assert repr(err) == "FreeRideError('An unspecified FreeRide error occurred.')"
+
+
+def test_formula_parse_error_defaults():
+    err = FormulaParseError()
+    assert str(err) == "Unable to parse formula string."
+    assert repr(err) == "FormulaParseError('Unable to parse formula string.')"
+
+
+def test_custom_message():
+    err = FormulaParseError("bad input")
+    assert str(err) == "bad input"
+    assert repr(err) == "FormulaParseError('bad input')"
+


### PR DESCRIPTION
## Summary
- customize the default FormulaParseError message
- add tests covering custom exceptions

## Testing
- `pytest -q`
