### PR TITLE
Add __str__ and __repr__ to FormulaParseError

### DIFF
--- a/freeride/exceptions.py
+++ b/freeride/exceptions.py
@@ -1,7 +1,30 @@
 class FreeRideError(Exception):
     """Base class for all FreeRide exceptions."""
 
+    def __init__(self, message: str | None = None) -> None:
+        if message is None:
+            message = "An unspecified FreeRide error occurred."
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self) -> str:  # pragma: no cover - simple return
+        return self.message
+
+    def __repr__(self) -> str:  # pragma: no cover - simple return
+        return f"{self.__class__.__name__}('{self.message}')"
 
 class FormulaParseError(FreeRideError):
     """Error raised when parsing a formula string fails."""
+
+    def __init__(self, message: str | None = None) -> None:
+        if message is None:
+            message = "Failed to parse formula."
+        super().__init__(message)
+
+    def __str__(self) -> str:  # pragma: no cover - simple return
+        return self.message
+
+    def __repr__(self) -> str:  # pragma: no cover - simple return
+        return f"{self.__class__.__name__}('{self.message}')"
+
 


### PR DESCRIPTION
## Summary
- refine `FormulaParseError` with its own initializer
- provide bespoke string and repr methods for `FormulaParseError`

## Testing
- `pytest -q`
