### PR TITLE
Add Bach or Stravinsky helper

### DIFF
--- a/freeride/games.py
+++ b/freeride/games.py
@@ -529,6 +529,22 @@ class Game:
         )
 
     @classmethod
+    def bach_or_stravinsky(cls) -> "Game":
+        """Return the Bach or Stravinsky coordination game."""
+
+        p1 = [[2, 0], [0, 1]]
+        p2 = [[1, 0], [0, 2]]
+        return cls(
+            p1,
+            p2,
+            player_names=("Anna", "Boris"),
+            action_names=(
+                ("Bach", "Stravinsky"),
+                ("Bach", "Stravinsky"),
+            ),
+        )
+
+    @classmethod
     def pure_coordination(cls) -> "Game":
         """Return a simple pure coordination game."""
 
@@ -584,4 +600,3 @@ class Game:
 
 # Backwards compatibility
 NormalFormGame = Game
-

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -210,6 +210,19 @@ class TestGame(unittest.TestCase):
         # Test nash equilibrium with proper action names
         self.assertEqual(set(bos.nash_equilibria()), {('Opera', 'Opera'), ('Boxing Match', 'Boxing Match')})
 
+        bos_alt = Game.bach_or_stravinsky()
+        self.assertEqual(bos_alt.payoffs1.tolist(), [[2, 0], [0, 1]])
+        self.assertEqual(bos_alt.payoffs2.tolist(), [[1, 0], [0, 2]])
+        self.assertEqual(bos_alt.player_names, ("Anna", "Boris"))
+        self.assertEqual(
+            bos_alt.action_names,
+            (("Bach", "Stravinsky"), ("Bach", "Stravinsky")),
+        )
+        self.assertEqual(
+            set(bos_alt.nash_equilibria()),
+            {("Bach", "Bach"), ("Stravinsky", "Stravinsky")},
+        )
+
         sh = Game.stag_hunt()
         self.assertEqual(sh.payoffs1.tolist(), [[2, 0], [1, 1]])
         self.assertEqual(sh.payoffs2.tolist(), [[2, 1], [0, 1]])


### PR DESCRIPTION
## Summary
- Refresh PR #85 against current `main` with one clean commit.
- Add `Game.bach_or_stravinsky()` as a labeled constructor matching the Battle of the Sexes payoff structure.
- Preserve the current built-in constructor convention by setting `player_names=("Anna", "Boris")` and `action_names=(("Bach", "Stravinsky"), ("Bach", "Stravinsky"))`.
- Add coverage for payoffs, player names, action names, and named Nash equilibria.

## Testing
- `pytest -q tests/test_games.py` -> 18 passed, 1 warning
- `pytest -q` -> 134 passed, 2 warnings
