### PR TITLE
Fix axes handling in cost_profit_plot

### DIFF
--- a/freeride/costs.py
+++ b/freeride/costs.py
@@ -375,8 +375,8 @@ class Cost(PolyBase):
         q = mc.q(p)
 
         # plot AC and MC
-        self.average_cost().plot(label = "ATC")
-        mc.plot(label = "MC")
+        self.average_cost().plot(ax=ax, label="ATC")
+        mc.plot(ax=ax, label="MC")
 
 
         # plot price and quantity

--- a/tests/test_longrun.py
+++ b/tests/test_longrun.py
@@ -19,5 +19,23 @@ class TestLongRunCompetitiveEquilibrium(unittest.TestCase):
         self.assertAlmostEqual(lr.n_firms, 8.0)
 
 
+class TestCostProfitPlot(unittest.TestCase):
+    def test_cost_profit_plot_respects_passed_axes(self):
+        import matplotlib.pyplot as plt
+        from unittest.mock import patch
+        from freeride.base import AffineElement
+
+        fig, (ax0, ax1) = plt.subplots(1, 2)
+        plt.sca(ax0)
+
+        c = Cost(1, 0, 1)
+
+        with patch.object(Cost, "marginal_cost", return_value=AffineElement(0, 1)):
+            c.cost_profit_plot(4, ax=ax1)
+
+        self.assertEqual(len(ax0.lines), 0)
+        self.assertGreaterEqual(len(ax1.lines), 5)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- pass caller-provided axis to ATC and MC plots in `Cost.cost_profit_plot`
- add regression test ensuring `cost_profit_plot` respects the supplied axis

## Testing
- `pytest -q`