### PR TITLE
Handle perfect segments in Affine curves

### DIFF
--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -141,6 +141,20 @@ class TestCurveEdgeCases(unittest.TestCase):
         with self.assertRaises(PPFError):
             PPF(10, 1)
 
+    def test_has_perfect_segment_property(self):
+        elastic = BaseAffine(5, 0, inverse=True)
+        self.assertTrue(elastic.has_perfect_segment)
+        regular = BaseAffine(12, -1, inverse=True)
+        self.assertFalse(regular.has_perfect_segment)
+
+    def test_demand_with_perfect_segment_no_negative_check(self):
+        # Ensure that creating a demand curve with a perfect segment
+        # does not raise due to negative-demand checks.
+        try:
+            BaseAffine(5, 0)
+        except Exception as e:
+            self.fail(f"BaseAffine raised {e} unexpectedly")
+
 
 class TestPPF(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- add `_has_perfect_segment` method and `has_perfect_segment` property to `BaseAffine`
- update demand and supply slope checks to ignore negative quantity tests when perfect segments exist
- test perfect segment detection and slope check bypass

## Testing
- `pytest -q`