### PR TITLE
Fix bare except blocks

### DIFF
--- a/freeride/affine.py
+++ b/freeride/affine.py
@@ -859,7 +859,7 @@ class Affine(BaseAffine):
                             q_val = piece.q(p)
                             if np.isfinite(q_val) and q_val >= 0:
                                 return q_val
-                        except:
+                        except Exception:
                             continue
                 else:
                     # Interior piece: use [a,b) convention
@@ -868,7 +868,7 @@ class Affine(BaseAffine):
                             q_val = piece.q(p)
                             if np.isfinite(q_val) and q_val >= 0:
                                 return q_val
-                        except:
+                        except Exception:
                             continue
             return 0
         else:
@@ -959,7 +959,7 @@ class Affine(BaseAffine):
                     return val
                 else:
                     return np.nan
-            except:
+            except Exception:
                 return np.nan
 
         if ax is None:

--- a/freeride/curves.py.backup
+++ b/freeride/curves.py.backup
@@ -475,7 +475,7 @@ class Affine(BaseAffine):
                         q_val = piece.q(p)
                         if np.isfinite(q_val) and q_val >= 0:
                             return q_val
-                    except:
+                    except Exception:
                         continue
             return 0
         else:
@@ -564,7 +564,7 @@ class Affine(BaseAffine):
                     return val
                 else:
                     return np.nan
-            except:
+            except Exception:
                 return np.nan
 
         if ax is None:


### PR DESCRIPTION
## Summary
- replace bare `except:` usage with `except Exception:`
- update `freeride/affine.py` and `freeride/curves.py.backup`

## Status
Closed as stale / not worth preserving as a standalone PR. The repo’s broader pylint issues should be handled separately with a real linting strategy rather than merging this narrow cleanup.

## Testing
- Not rerun for closure.

------
https://chatgpt.com/codex/tasks/task_e_68658aae3b488327a565dfa932a25149