### PR TITLE
Add repr methods for Monopoly

### DIFF
--- a/freeride/monopoly.py
+++ b/freeride/monopoly.py
@@ -103,3 +103,11 @@ class Monopoly:
         self.q = best_q
         self.p = self.demand.p(best_q)
         self.profit = best_profit
+
+    def __repr__(self) -> str:
+        """Return a concise text summary of the monopoly outcome."""
+        return f"Monopoly: Q = {self.q:g}, P = {self.p:g}, Profit = {self.profit:g}"
+
+    def _repr_latex_(self) -> str:
+        """Return a LaTeX summary for notebook display."""
+        return f"$Q^* = {self.q:g},\\ P^* = {self.p:g},\\ \\Pi = {self.profit:g}$"

--- a/tests/test_monopoly.py
+++ b/tests/test_monopoly.py
@@ -14,6 +14,15 @@ class TestMonopoly(unittest.TestCase):
         self.assertAlmostEqual(m.p, 6.0)
         self.assertAlmostEqual(m.profit, 16.0)
 
+    def test_repr_methods(self):
+        """Monopoly representations should summarize the solved outcome."""
+        monopoly = Monopoly(Demand(10, -1), Cost(0, 2))
+        self.assertEqual(repr(monopoly), "Monopoly: Q = 4, P = 6, Profit = 16")
+        self.assertEqual(
+            monopoly._repr_latex_(),
+            "$Q^* = 4,\\ P^* = 6,\\ \\Pi = 16$",
+        )
+
     def test_piecewise_demand_zero_cost(self):
         """Profit maximization with piecewise demand and zero cost."""
         demand = Demand([10, 5], [-1, -1])


### PR DESCRIPTION
## Summary
- Refresh PR #159 against current `main` with one clean commit.
- Add concise terminal and notebook representations for `Monopoly`.
- Use the idiomatic text format `Monopoly: Q = 4, P = 6, Profit = 16` with `:g` numeric formatting.
- Add Monopoly-specific coverage in `tests/test_monopoly.py`.

## Testing
- `pytest -q tests/test_monopoly.py` -> 7 passed, 1 warning
- `pytest -q tests/test_repr_methods.py` -> 8 passed, 3 warnings
- `pytest -q` -> 137 passed, 2 warnings
