### PR TITLE
ppf bug

### DIFF
--- a/freeride/__init__.py
+++ b/freeride/__init__.py
@@ -1,7 +1,7 @@
 """Expose the package version and core FreeRide classes."""
 
 # FreeRide
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 from .curves import Demand, Supply
 from .equilibrium import Equilibrium, Market

--- a/freeride/__init__.py
+++ b/freeride/__init__.py
@@ -1,7 +1,7 @@
 """Expose the package version and core FreeRide classes."""
 
 # FreeRide
-__version__ = '0.1.2'
+__version__ = '0.1.1'
 
 from .curves import Demand, Supply
 from .equilibrium import Equilibrium, Market

--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -54,11 +54,11 @@ def ppf_sum(*curves, comparative_advantage=True):
         aggregate frontier.
     """
 
-    slope_and_curves = sorted(
-        [(s.slope, s) for s in curves],
+    curves = sorted(
+        curves,
+        key=lambda s: s.slope,
         reverse=comparative_advantage,
     )
-    curves = [t[1] for t in slope_and_curves]
     x_intercepts = [c.q_intercept for c in curves]
     y_intercepts = [c.intercept for c in curves]
 

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -236,6 +236,31 @@ class TestPPF(unittest.TestCase):
         p2 = PPF(5, -0.5)
         self.assertAlmostEqual((p1 + p2)(7), (p2 + p1)(7))
 
+    def test_addition_with_equal_slopes(self):
+        """Test PPF addition when both curves have the same slope."""
+        ppf1 = PPF.from_formula('x = 10 - y')
+        ppf2 = PPF.from_formula('x = 8 - y')
+        # Both have slope -1, which previously caused a TypeError
+        joint = ppf1 + ppf2
+        self.assertIsInstance(joint, PPF)
+        # The combined PPF should have x-intercept of 18 (10 + 8)
+        self.assertAlmostEqual(joint(0), 18.0)
+        # At x=10, we should have y=8 (using the second PPF segment)
+        self.assertAlmostEqual(joint(10), 8.0)
+        # At x=18, we should have y=0
+        self.assertAlmostEqual(joint(18), 0.0)
+
+    def test_addition_multiple_equal_slopes(self):
+        """Test PPF addition with more than two curves with equal slopes."""
+        ppf1 = PPF(10, -1)
+        ppf2 = PPF(8, -1)
+        ppf3 = PPF(6, -1)
+        joint = ppf1 + ppf2 + ppf3
+        self.assertIsInstance(joint, PPF)
+        # Combined x-intercept should be 10 + 8 + 6 = 24
+        self.assertAlmostEqual(joint(0), 24.0)
+        self.assertAlmostEqual(joint(24), 0.0)
+
 
 class TestBaseQuadraticRegression(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- Fix PPF addition when multiple component PPFs have identical slopes.
- Sort PPF components by slope using a key function instead of sorting `(slope, curve)` tuples, avoiding comparisons between curve objects when slopes tie.
- Add regression coverage for adding two and three same-slope PPFs.
- Refresh the branch against current `main` after PR #85 merged.
- Leave the package version unchanged; version bumps should be handled separately for releases.

## Testing
- `pytest -q tests/test_curves.py -k "PPF or BaseQuadratic"` -> 10 passed
