### PR TITLE
Support perfect-segment (horizontal/vertical) curve intersections in Equilibrium

### DIFF
--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -55,20 +55,6 @@ class Equilibrium:
             world_price=None,
             tariff=0
     ):
-        # Check for perfectly elastic or inelastic curves
-        if demand.has_perfect_segment:
-            raise ValueError(
-                "Equilibrium does not currently support perfectly elastic or inelastic demand curves "
-                "due to implementation limitations (not economic theory). "
-                "These curves have indeterminate quantities at the equilibrium price."
-            )
-        if supply.has_perfect_segment:
-            raise ValueError(
-                "Equilibrium does not currently support perfectly elastic or inelastic supply curves "
-                "due to implementation limitations (not economic theory). "
-                "These curves have indeterminate quantities at the equilibrium price."
-            )
-
         self.demand = demand
         self.supply = supply
 
@@ -188,10 +174,20 @@ class Equilibrium:
         self._net_imports = Qd - Qs
 
     def _find_intersection(self, dcurve, scurve):
+        if dcurve.has_perfect_segment or scurve.has_perfect_segment:
+            perfect_solution = self._solve_with_perfect_segments(
+                dcurve, scurve
+            )
+            if perfect_solution is not None:
+                return perfect_solution
+
         for dpiece in dcurve.pieces:
             for spiece in scurve.pieces:
                 if dpiece and spiece:
-                    p_temp, q_temp = intersection(dpiece, spiece)
+                    try:
+                        p_temp, q_temp = intersection(dpiece, spiece)
+                    except np.linalg.LinAlgError:
+                        continue
                     if self._valid_in_domain(dpiece, spiece, q_temp):
                         return p_temp, q_temp
 
@@ -203,14 +199,89 @@ class Equilibrium:
         p = 0.5*(p_max+p_min)
         return p, 0
 
+    def _solve_with_perfect_segments(self, dcurve, scurve):
+        candidates = []
+        has_unsupported = False
+        has_fixed_price_indeterminacy = False
+
+        for dpiece in dcurve.pieces:
+            for spiece in scurve.pieces:
+                if not (dpiece and spiece):
+                    continue
+
+                d_horizontal = dpiece.slope == 0
+                s_horizontal = spiece.slope == 0
+                d_vertical = np.isinf(dpiece.slope)
+                s_vertical = np.isinf(spiece.slope)
+                d_regular = not (d_horizontal or d_vertical)
+                s_regular = not (s_horizontal or s_vertical)
+
+                # Horizontal demand/supply against regular opposite curve.
+                if (d_horizontal and s_regular) or (d_regular and s_horizontal):
+                    p_temp, q_temp = intersection(dpiece, spiece)
+                    if self._valid_in_domain(dpiece, spiece, q_temp):
+                        candidates.append((p_temp, q_temp))
+                    continue
+
+                # Vertical demand/supply against regular opposite curve.
+                if (d_vertical and s_regular) or (d_regular and s_vertical):
+                    p_temp, q_temp = intersection(dpiece, spiece)
+                    if self._valid_in_domain(dpiece, spiece, q_temp):
+                        candidates.append((p_temp, q_temp))
+                    continue
+
+                # Horizontal vs vertical gives a single point if domains allow.
+                if (d_horizontal and s_vertical) or (d_vertical and s_horizontal):
+                    p_temp, q_temp = intersection(dpiece, spiece)
+                    if self._valid_in_domain(dpiece, spiece, q_temp):
+                        candidates.append((p_temp, q_temp))
+                    continue
+
+                # Horizontal vs horizontal can pin a price but not quantity.
+                if d_horizontal and s_horizontal:
+                    if np.isclose(dpiece.intercept, spiece.intercept):
+                        has_fixed_price_indeterminacy = True
+                    else:
+                        has_unsupported = True
+                    continue
+
+                # Vertical vs vertical is not handled by this equilibrium model.
+                if d_vertical and s_vertical:
+                    has_unsupported = True
+
+        if len(candidates) == 1:
+            p_star, q_star = candidates[0]
+            return float(p_star), float(q_star)
+
+        if len(candidates) > 1:
+            unique_candidates = {
+                (round(float(p), 12), round(float(q), 12))
+                for p, q in candidates
+            }
+            if len(unique_candidates) == 1:
+                return tuple(unique_candidates.pop())
+            raise ValueError(
+                "unsupported combination: multiple distinct perfect-segment intersections"
+            )
+
+        if has_fixed_price_indeterminacy:
+            raise ValueError(
+                "economically indeterminate quantity at fixed price"
+            )
+        if has_unsupported:
+            raise ValueError(
+                "unsupported combination: perfect-segment pairing not implemented"
+            )
+        return None
+
     def _valid_in_domain(self, dpiece, spiece, q_val):
         d_dom = dpiece._domain
         s_dom = spiece._domain
         if d_dom:
-            if not (d_dom[1] <= q_val <= d_dom[0]):
+            if not (min(d_dom) <= q_val <= max(d_dom)):
                 return False
         if s_dom:
-            if not (s_dom[0] <= q_val <= s_dom[1]):
+            if not (min(s_dom) <= q_val <= max(s_dom)):
                 return False
         return True
 

--- a/tests/test_horizontal_curves.py
+++ b/tests/test_horizontal_curves.py
@@ -71,28 +71,39 @@ class TestHorizontalCurves(unittest.TestCase):
             # Below P=10, should return inf
             self.assertTrue(np.isinf(d.q(9)))
 
-    def test_equilibrium_blocks_horizontal_supply(self):
-        """Test that Equilibrium blocks horizontal supply curves."""
+    def test_equilibrium_allows_horizontal_supply_with_regular_demand(self):
+        """Horizontal supply with regular demand should produce a unique point."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             s = Supply(5, 0)  # Horizontal supply
             d = Demand(10, -1)  # Normal demand
 
-            with self.assertRaises(ValueError) as cm:
-                eq = Equilibrium(d, s)
+            eq = Equilibrium(d, s)
+            self.assertEqual(eq.p, 5)
+            self.assertEqual(eq.q, 5)
 
-            self.assertIn("perfectly elastic", str(cm.exception))
-            self.assertIn("supply", str(cm.exception).lower())
-
-    def test_equilibrium_blocks_horizontal_demand(self):
-        """Test that Equilibrium blocks horizontal demand curves."""
+    def test_equilibrium_allows_horizontal_demand_with_regular_supply(self):
+        """Horizontal demand with regular supply should produce a unique point."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             d = Demand(8, 0)  # Horizontal demand
             s = Supply(2, 1)  # Normal supply
 
-            with self.assertRaises(ValueError) as cm:
-                eq = Equilibrium(d, s)
+            eq = Equilibrium(d, s)
+            self.assertEqual(eq.p, 8)
+            self.assertEqual(eq.q, 6)
 
-            self.assertIn("perfectly elastic", str(cm.exception))
-            self.assertIn("demand", str(cm.exception).lower())
+    def test_equilibrium_horizontal_horizontal_is_indeterminate(self):
+        """Equal fixed-price demand and supply should raise an indeterminate error."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            d = Demand(8, 0)
+            s = Supply(8, 0)
+
+            with self.assertRaises(ValueError) as cm:
+                Equilibrium(d, s)
+
+            self.assertIn(
+                "economically indeterminate quantity at fixed price",
+                str(cm.exception),
+            )


### PR DESCRIPTION
### Motivation
- Equilibrium previously rejected any demand or supply with perfectly elastic/​inelastic segments at construction (`Equilibrium.__init__`) which prevented valid intersections from being computed; the goal is to handle common perfect-segment combinations instead of blocking them. 
- The change moves special-case handling into the intersection logic so `Equilibrium._compute`/`_find_intersection` can return a deterministic `(p, q)` when the geometry uniquely pins an outcome. 
- When economic indeterminacy (price pinned but quantity not) or genuinely unsupported pairings occur, the model should raise clear, specific errors rather than a blanket rejection. 

### Description
- Removed the unconditional perfect-segment rejection from `Equilibrium.__init__` so curves with perfect segments may be used.  
- Added a helper `Equilibrium._solve_with_perfect_segments(dcurve, scurve)` that inspects piece combinations and handles: horizontal vs regular, vertical vs regular, and horizontal vs vertical cases, collecting candidate `(p,q)` solutions and returning a unique deterministic pair when possible. 
- Wired the helper into `Equilibrium._find_intersection` to run before the regular piecewise intersection loop and preserved the affine fallback behavior for ordinary cases. 
- Introduced distinct error messages for failure modes: `"economically indeterminate quantity at fixed price"` for price-equal horizontal pairs and `"unsupported combination: ..."` for other unhandled perfect-segment pairings or multiple distinct perfect-segment intersections. 
- Made domain validation in `_valid_in_domain` orientation-safe by using `min/max` on piece domains so intersections validate correctly regardless of domain ordering. 
- Updated tests in `tests/test_horizontal_curves.py` to reflect supported perfect-segment outcomes and the new indeterminate error case. 

### Testing
- Ran `pytest -q tests/test_horizontal_curves.py tests/test_equilibrium.py tests/test_world_price.py` and all tests passed (`15 passed`).
- The updated horizontal-curve tests exercise horizontal vs regular and horizontal vs horizontal indeterminacy and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fcb0bd4c83278a40efcc74593f48)