### PR TITLE
Harden kink detection in Affine.price_elasticity

### DIFF
--- a/freeride/affine.py
+++ b/freeride/affine.py
@@ -899,12 +899,22 @@ class Affine(BaseAffine):
             latex_str += r"\end{cases}"
             return f"${latex_str}$"
 
-    def price_elasticity(self, p, delta=.000001):
+    def price_elasticity(self, p, delta=.000001, atol=1e-12, rtol=1e-9):
         q = self.q(p)
         pt = np.array([p,q])
-        if self.intersections and np.any(pt == self.intersections, axis=1).max():
-            below = self.price_elasticity(p - delta)
-            above = self.price_elasticity(p + delta)
+        intersections = np.asarray(self.intersections)
+        is_kink = (
+            intersections.size > 0
+            and intersections.ndim == 2
+            and intersections.shape[1] == 2
+            and np.any(
+                np.isclose(pt[0], intersections[:, 0], atol=atol, rtol=rtol)
+                & np.isclose(pt[1], intersections[:, 1], atol=atol, rtol=rtol)
+            )
+        )
+        if is_kink:
+            below = self.price_elasticity(p - delta, delta=delta, atol=atol, rtol=rtol)
+            above = self.price_elasticity(p + delta, delta=delta, atol=atol, rtol=rtol)
             s = f"\nElasticity is {below:+.3f} below P={p} and {above:+.3f} above."
             raise ValueError("Point elasticity is not defined at a kink point."+s)
         else:

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -126,6 +126,29 @@ class TestCurveHelpers(unittest.TestCase):
         self.assertIsNone(active[2])
 
 
+class TestAffinePriceElasticityKinks(unittest.TestCase):
+    def setUp(self):
+        d1 = Demand(12, -1)
+        d2 = Demand(6, -0.5)
+        self.kinked_demand = d1 + d2
+        self.kink_p = self.kinked_demand.intersections[0][0]
+
+    def test_exact_kink_input_raises(self):
+        with self.assertRaisesRegex(ValueError, "kink point"):
+            self.kinked_demand.price_elasticity(self.kink_p)
+
+    def test_near_kink_input_does_not_raise(self):
+        elasticity = self.kinked_demand.price_elasticity(self.kink_p + 1e-7)
+        self.assertTrue(np.isfinite(elasticity))
+
+    def test_floating_point_kink_representation_raises(self):
+        # 0.1 + 0.2 is not exactly representable; scaled here it lands
+        # extremely close to the true kink price of 6.
+        p_with_fp_noise = (0.1 + 0.2) * 20
+        with self.assertRaisesRegex(ValueError, "kink point"):
+            self.kinked_demand.price_elasticity(p_with_fp_noise)
+
+
 class TestSurplusAndRevenue(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
### Motivation
- Avoid brittle float-equality when detecting kink points so that true kinks reliably raise an error while nearby floating-point-noisy inputs do not.
- Make kink detection configurable via tolerances so callers can control sensitivity for FP edge cases.

### Description
- Replaced exact `pt == self.intersections` matching with `np.isclose` checks on both price and quantity coordinates against `self.intersections`, converting intersections to `np.asarray` for safe checks.
- Exposed tolerance parameters on `Affine.price_elasticity` as `atol` and `rtol` with sensible defaults `1e-12` and `1e-9`, and threaded them through recursive above/below probes so diagnostics use the same tolerances.
- Added shape/size guards when inspecting `self.intersections` so detection only runs for properly-shaped intersection arrays.
- Added regression tests in `tests/test_curves.py` (`TestAffinePriceElasticityKinks`) covering exact-kink input (should raise), near-kink input (should not raise), and a floating-point representation edge case that should still be treated as a kink.

### Testing
- Ran `pytest -q tests/test_curves.py -k kink` and observed `3 passed` for the kink-focused tests.
- Ran `pytest -q tests/test_curves.py` and observed `32 passed` indicating the module-level test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c7fc735fe88327bea7d506df0dbbc0)