### PR TITLE
Add tax incidence properties

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,10 +94,14 @@ We can easily add a tax to the market and visualize its effects.
 
    # Apply a $2.50 tax
    market.tax = 2.5
+   print(f"Consumer burden: ${market.consumer_tax_burden:.2f}")
+   print(f"Producer burden: ${market.producer_tax_burden:.2f}")
+   print(f"Consumer share: {market.consumer_tax_share:.0%}")
    market.plot(surplus=True)
 
 This plot shows the higher price paid by consumers, the lower price
-received by producers, and the shaded tax revenue rectangle.
+received by producers, and the shaded tax revenue rectangle. The burden
+properties show how much of the tax is borne by each side of the market.
 
 .. image:: _static/tax_example_plot.svg
    :alt: Market plot with tax revenue shaded

--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -248,6 +248,38 @@ class Equilibrium:
         return -self.govt_revenue
 
     @property
+    def tax_wedge(self):
+        return self.__p_consumer - self.__p_producer
+
+    @property
+    def consumer_tax_burden(self):
+        if self.__tax == 0:
+            return 0.0
+        return self.__p_consumer - self._free_market_price()
+
+    @property
+    def producer_tax_burden(self):
+        if self.__tax == 0:
+            return 0.0
+        return self._free_market_price() - self.__p_producer
+
+    @property
+    def consumer_tax_share(self):
+        if self.__tax == 0:
+            return 0.0
+        return self.consumer_tax_burden / self.__tax
+
+    @property
+    def producer_tax_share(self):
+        if self.__tax == 0:
+            return 0.0
+        return self.producer_tax_burden / self.__tax
+
+    def _free_market_price(self):
+        p_star, _ = self._find_intersection(self.demand, self.supply)
+        return p_star
+
+    @property
     def total_surplus(self):
         return (
             self.consumer_surplus

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -32,3 +32,46 @@ class TestEquilibrium(unittest.TestCase):
         self.assertEqual(eq_floor.q, self.equilibrium.q)
         if hasattr(eq_floor, "excess_supply"):
             self.assertEqual(eq_floor.excess_supply, 0)
+
+    def test_symmetric_tax_incidence(self):
+        demand = Demand(10, -1)
+        supply = Supply(0, 1)
+        eq_tax = Equilibrium(demand, supply, tax=2)
+        self.assertAlmostEqual(eq_tax.tax_wedge, 2.0)
+        self.assertAlmostEqual(eq_tax.consumer_tax_burden, 1.0)
+        self.assertAlmostEqual(eq_tax.producer_tax_burden, 1.0)
+        self.assertAlmostEqual(eq_tax.consumer_tax_share, 0.5)
+        self.assertAlmostEqual(eq_tax.producer_tax_share, 0.5)
+
+    def test_inelastic_demand_places_more_tax_burden_on_consumers(self):
+        demand = Demand(10, -4)
+        supply = Supply(0, 1)
+        eq_tax = Equilibrium(demand, supply, tax=2)
+        self.assertAlmostEqual(eq_tax.consumer_tax_burden, 1.6)
+        self.assertAlmostEqual(eq_tax.producer_tax_burden, 0.4)
+        self.assertGreater(
+            eq_tax.consumer_tax_share,
+            eq_tax.producer_tax_share,
+        )
+        self.assertAlmostEqual(
+            eq_tax.consumer_tax_share + eq_tax.producer_tax_share,
+            1.0,
+        )
+
+    def test_no_tax_has_zero_tax_incidence(self):
+        self.assertAlmostEqual(self.equilibrium.tax_wedge, 0.0)
+        self.assertAlmostEqual(self.equilibrium.consumer_tax_burden, 0.0)
+        self.assertAlmostEqual(self.equilibrium.producer_tax_burden, 0.0)
+        self.assertAlmostEqual(self.equilibrium.consumer_tax_share, 0.0)
+        self.assertAlmostEqual(self.equilibrium.producer_tax_share, 0.0)
+
+    def test_subsidy_incidence_uses_signed_burdens(self):
+        demand = Demand(10, -1)
+        supply = Supply(0, 1)
+        eq_subsidy = Equilibrium(demand, supply)
+        eq_subsidy.subsidy = 2
+        self.assertAlmostEqual(eq_subsidy.tax_wedge, -2.0)
+        self.assertAlmostEqual(eq_subsidy.consumer_tax_burden, -1.0)
+        self.assertAlmostEqual(eq_subsidy.producer_tax_burden, -1.0)
+        self.assertAlmostEqual(eq_subsidy.consumer_tax_share, 0.5)
+        self.assertAlmostEqual(eq_subsidy.producer_tax_share, 0.5)


### PR DESCRIPTION
## Summary
- Add explicit tax incidence properties to `Equilibrium`/`Market` for introductory per-unit tax and subsidy analysis.
- Expose the tax wedge, consumer and producer burden amounts, and burden shares using the existing `p_consumer` / `p_producer` tax machinery.
- Add a short docs example to the existing Basic Tax Example showing how to inspect the burden split.

## Behavior
- `tax_wedge` reports `p_consumer - p_producer`.
- `consumer_tax_burden` and `producer_tax_burden` compare tax/subsidy prices against the no-intervention market price.
- `consumer_tax_share` and `producer_tax_share` divide those signed burdens by the signed tax.
- No-tax cases return zero incidence values, keeping price controls and world-price behavior out of scope.

## Validation
- `pytest -q tests/test_equilibrium.py tests/test_world_price.py` passed: 12 passed, 1 warning.
- `pytest -q` passed: 141 passed, 2 warnings.

## Notes
This PR is intentionally limited to closed-economy per-unit tax incidence. It does not change tariff behavior, plotting, notebooks, or version numbers.