### PR TITLE
Fix formula parsing on Python 3.14

### DIFF
--- a/freeride/formula.py
+++ b/freeride/formula.py
@@ -28,9 +28,6 @@ def _eval_ast_node(node, allowed_names, values):
         operand = _eval_ast_node(node.operand, allowed_names, values)
         return operand if isinstance(node.op, ast.UAdd) else -operand
     
-    if isinstance(node, ast.Num):  # Python <3.8 compatibility
-        return node.n
-    
     if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
         return node.value
     


### PR DESCRIPTION
### Motivation
- Fix a failure in the safe formula evaluator when running on Python 3.14 where `ast.Num` is no longer present, which caused `AttributeError` and prevented affine/quadratic formula parsing used by demand/supply/PPF/revenue code paths.

### Description
- Remove the obsolete `ast.Num` compatibility branch in `freeride/formula.py` and rely on `ast.Constant` for numeric literals in the restricted AST evaluator, keeping the rest of the parsing logic intact.

### Testing
- Ran `pytest -q` and `python -m unittest discover tests/`, both succeeded with `137 passed`, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6528777d6c8327a4a9771162655a77)