### PR TITLE
Add market diagnostics to Equilibrium and update docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ print(e.p, e.q)
 e.plot()
 ```
 
+Markets also expose Econ 101 price-control diagnostics directly. Binding
+controls report ``quantity_demanded``, ``quantity_supplied``, ``shortage``, and
+``excess_supply``:
+
+```python
+controlled = Equilibrium(d, s, ceiling=4)
+print(controlled.quantity_demanded, controlled.quantity_supplied)
+print(controlled.shortage)
+```
+
 Use matplotlib to customize plots further. 
 
 ```
@@ -69,4 +79,3 @@ plt.show()
 ```
 
 ![equilibrium.svg](equilibrium.svg)
-

--- a/docs/tutorials/price_controls.rst
+++ b/docs/tutorials/price_controls.rst
@@ -62,15 +62,10 @@ A binding price ceiling creates a shortage because quantity demanded exceeds qua
    # Apply a binding price ceiling at $8
    ceiling_market = Market(demand, supply, ceiling=8)
    
-   # Calculate shortage
-   q_demanded = demand.q(8)
-   q_supplied = supply.q(8)
-   shortage = q_demanded - q_supplied
-   
    print(f"With Price Ceiling at $8:")
-   print(f"  Quantity Supplied: {q_supplied:.0f}")
-   print(f"  Quantity Demanded: {q_demanded:.0f}")
-   print(f"  Shortage: {shortage:.0f} units")
+   print(f"  Quantity Supplied: {ceiling_market.quantity_supplied:.0f}")
+   print(f"  Quantity Demanded: {ceiling_market.quantity_demanded:.0f}")
+   print(f"  Shortage: {ceiling_market.shortage:.0f} units")
    print(f"  Deadweight Loss: ${ceiling_market.dwl:.2f}")
    
    # Visualize the market with ceiling
@@ -99,15 +94,10 @@ A binding price floor creates a surplus because quantity supplied exceeds quanti
    # Apply a binding price floor at $12
    floor_market = Market(demand, supply, floor=12)
    
-   # Calculate surplus
-   q_demanded = demand.q(12)
-   q_supplied = supply.q(12)
-   surplus = q_supplied - q_demanded
-   
    print(f"With Price Floor at $12:")
-   print(f"  Quantity Demanded: {q_demanded:.0f}")
-   print(f"  Quantity Supplied: {q_supplied:.0f}")
-   print(f"  Surplus: {surplus:.0f} units")
+   print(f"  Quantity Demanded: {floor_market.quantity_demanded:.0f}")
+   print(f"  Quantity Supplied: {floor_market.quantity_supplied:.0f}")
+   print(f"  Surplus: {floor_market.excess_supply:.0f} units")
    print(f"  Deadweight Loss: ${floor_market.dwl:.2f}")
    
    # Visualize the market with floor

--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -255,6 +255,35 @@ class Equilibrium:
             + self.govt_revenue
         )
 
+    # ================== Market diagnostics ==================#
+    @property
+    def quantity_demanded(self):
+        """Quantity consumers wish to buy at the price they pay.
+
+        This can differ from the quantity actually traded when a price
+        control binds or when the economy trades at a world price.
+        """
+        return self.demand.q(self.__p_consumer)
+
+    @property
+    def quantity_supplied(self):
+        """Quantity producers wish to sell at the price they receive."""
+        return self.supply.q(self.__p_producer)
+
+    @property
+    def shortage(self):
+        """Unmet demand under a binding price ceiling, otherwise zero."""
+        if self.__ceiling is None:
+            return 0
+        return max(self.quantity_demanded - self.quantity_supplied, 0)
+
+    @property
+    def excess_supply(self):
+        """Unsold supply under a binding price floor, otherwise zero."""
+        if self.__floor is None:
+            return 0
+        return max(self.quantity_supplied - self.quantity_demanded, 0)
+
     # ================== Plot ==================#
     def plot(self, ax=None, surplus=False):
         if ax is None:

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -32,3 +32,37 @@ class TestEquilibrium(unittest.TestCase):
         self.assertEqual(eq_floor.q, self.equilibrium.q)
         if hasattr(eq_floor, "excess_supply"):
             self.assertEqual(eq_floor.excess_supply, 0)
+
+    def test_binding_ceiling_reports_shortage(self):
+        market = Equilibrium(self.demand_curve, self.supply_curve, ceiling=5)
+        self.assertEqual(market.quantity_demanded, 10)
+        self.assertEqual(market.quantity_supplied, 6)
+        self.assertEqual(market.shortage, 4)
+        self.assertEqual(market.excess_supply, 0)
+
+    def test_binding_floor_reports_excess_supply(self):
+        market = Equilibrium(self.demand_curve, self.supply_curve, floor=7)
+        self.assertEqual(market.quantity_demanded, 6)
+        self.assertEqual(market.quantity_supplied, 10)
+        self.assertEqual(market.shortage, 0)
+        self.assertEqual(market.excess_supply, 4)
+
+    def test_nonbinding_price_control_has_no_shortage(self):
+        market = Equilibrium(self.demand_curve, self.supply_curve, ceiling=8)
+        self.assertEqual(market.shortage, 0)
+
+    def test_control_at_equilibrium_has_no_imbalance(self):
+        ceiling = Equilibrium(self.demand_curve, self.supply_curve, ceiling=6)
+        floor = Equilibrium(self.demand_curve, self.supply_curve, floor=6)
+        self.assertEqual(ceiling.shortage, 0)
+        self.assertEqual(floor.excess_supply, 0)
+
+    def test_trade_imbalance_is_not_a_shortage(self):
+        market = Equilibrium(
+            self.demand_curve,
+            self.supply_curve,
+            world_price=5,
+        )
+        self.assertGreater(market.imports, 0)
+        self.assertEqual(market.shortage, 0)
+        self.assertEqual(market.excess_supply, 0)


### PR DESCRIPTION
### Motivation

- Expose common Econ 101 diagnostics (quantities demanded/supplied and imbalances) directly from the market object to avoid manual recomputation. 
- Make examples and tutorials simpler and more idiomatic by using properties on `Equilibrium` instead of calling curve methods externally. 
- Provide clear programmatic access to identify binding controls vs. trade imbalances (e.g. world price) for downstream logic and plotting.

### Description

- Added market diagnostic properties to `Equilibrium`: `quantity_demanded`, `quantity_supplied`, `shortage`, and `excess_supply` that compute quantities at the consumer/producer prices. 
- Updated `README.md` with a short example showing how to inspect `quantity_demanded`, `quantity_supplied`, and `shortage`. 
- Updated the tutorial `docs/tutorials/price_controls.rst` to use the new `Equilibrium` properties in examples instead of computing quantities manually. 
- Added unit tests in `tests/test_equilibrium.py` to validate binding ceilings and floors, non-binding controls, equilibrium-edge cases, and that trade imbalances from `world_price` do not count as shortages.

### Testing

- Ran the automated test suite with `pytest` which executed the updated `tests/test_equilibrium.py` tests. 
- All new and existing unit tests completed successfully. 
- The added tests verify expected values for `quantity_demanded`, `quantity_supplied`, `shortage`, and `excess_supply` under binding and non-binding controls and for world price scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a663626e988832793216d36cb48d687)